### PR TITLE
Use cached QTH.

### DIFF
--- a/_tools/magic-ring-binder/receivers.py
+++ b/_tools/magic-ring-binder/receivers.py
@@ -32,20 +32,19 @@ def receiver_info(payload_json):
                 }
 
             # Listener telemetry?
-            if 'latest_listener_telemetry' in info:
-                if not 'ltelem' in receivers[callsign]:
+            if not 'ltelem' in receivers[callsign]:
+                if 'latest_listener_telemetry' in info:
                     receivers[callsign]['ltelem'] = db.get(
                         info['latest_listener_telemetry'])
+                    ltelem = receivers[callsign]['ltelem']
 
-                ltelem = receivers[callsign]['ltelem']
-
-                # Lookup country?
-                if not 'country' in receivers[callsign]:
                     c = countries.get_country(ltelem['data'])
                     if c:
                         print "Found {} in {}".format(callsign, c['name'])
                         receivers[callsign]['country'] = c
 
+            if 'ltelem' in receivers[callsign]:
+                ltelem = receivers[callsign]['ltelem']
                 # Calculate great circle distance
                 dist = distance.gc(ltelem['data'], t['doc']['data'])
 


### PR DESCRIPTION
Habitat RX location can timeout overnight. Magic Ring Binder only uses the first location in the Database, so the expected behaviour is to calculate Max Distance  from the cached QTH. Current code ignores strings with no QTH, even if there is already a location in the cache.